### PR TITLE
Fix backend checkbox not clickable issue by altering CSS

### DIFF
--- a/app/assets/stylesheets/admin/ace.css.scss
+++ b/app/assets/stylesheets/admin/ace.css.scss
@@ -2,3 +2,8 @@
   height: 300px;
   width: 100%;
 }
+
+label input[type='checkbox'].form-control {
+  width: auto;
+  height: auto;
+}


### PR DESCRIPTION
Fix backend checkbox in horizontal_form not clickable issue by applying extra CSS style.

```css
label input[type='checkbox'].form-control {
  width: auto;
  height: auto;
}
```