### PR TITLE
Adjust blog layout and fix size of company logo in footer

### DIFF
--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -8,16 +8,17 @@
       <%= breadcrumb t('.title') %>
     <% end %>
     <div class="row">
-      <aside class="col-md-4">
-        <%= render 'sidebar' %>
-      </aside>
-      <div class="col-md-8">
+
+      <div class="col-md-8 col-md-push-4">
         <%= render @posts %>
         <hr>
         <div class="text-center">
           <%= paginate @posts %>
         </div>
       </div><!-- End col-md-8-->
+      <aside class="col-md-4 col-md-pull-8">
+        <%= render 'sidebar' %>
+      </aside>
     </div>  <!-- End row-->
   </div><!-- End container -->
 </section><!-- End main_content-->

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -2,14 +2,14 @@
   <div class="container">
     <%= breadcrumb link_to(t('.title'), posts_path), tr(@post, :title) %>
     <div class="row">
-      <aside class="col-md-4">
-        <%= render '/posts/sidebar' %>
-      </aside>
-      <div class="col-md-8">
+      <div class="col-md-8 col-md-push-4">
         <%= render partial: '/posts/post', locals: {post: @post} %>
         <hr>
         <%= render 'layouts/disqus' %>
       </div>
+      <aside class="col-md-4 col-md-pull-8">
+        <%= render '/posts/sidebar' %>
+      </aside>
     </div>
   </div>
 </section>

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -1,5 +1,5 @@
 /*
-Theme Name: 
+Theme Name:
 Theme URI: http://www.ansonika.com/learn/
 Author: Ansonika
 Author URI: http://themeforest.net/user/Ansonika/
@@ -133,6 +133,9 @@ a#logo {
 /* TYPOGRAPHY and links color */
 p {
 	margin-bottom:20px;
+}
+code {
+	white-space: normal;
 }
 blockquote.styled {
 	line-height:20px;
@@ -356,11 +359,11 @@ a.button_top {
 	color:#fff;
 	font-size:11px;
 	padding:5px 16px 2px 16px;
-	text-decoration:none; 
-	transition: background .5s ease; 
-	-moz-transition: background .5s ease; 
-	-webkit-transition: background .5s ease; 
-	-o-transition: background .5s ease; 
+	text-decoration:none;
+	transition: background .5s ease;
+	-moz-transition: background .5s ease;
+	-webkit-transition: background .5s ease;
+	-o-transition: background .5s ease;
 	display:inline-block;
 	-webkit-border-radius: 3px;
 	-moz-border-radius: 3px;
@@ -375,7 +378,7 @@ a.button_top#apply {
 	border:none;
 	margin-top:5px;
 	background: #F66;
-	
+
 }
 a.button_top:hover {background:#30d9a4; color:#fff;}
 
@@ -384,11 +387,11 @@ a.button_medium, .button_medium {
 	background:#30d9a4;
 	color:#fff;
 	padding:7px 12px;
-	text-decoration:none; 
-	transition: background .5s ease; 
-	-moz-transition: background .5s ease; 
-	-webkit-transition: background .5s ease; 
-	-o-transition: background .5s ease; 
+	text-decoration:none;
+	transition: background .5s ease;
+	-moz-transition: background .5s ease;
+	-webkit-transition: background .5s ease;
+	-o-transition: background .5s ease;
 	display:inline-block;
 	cursor:pointer;
 	outline:none;
@@ -404,11 +407,11 @@ a.button_subscribe, .button_subscribe {
 	background:#ffd200;
 	color:#fff;
 	padding:12px 20px;
-	text-decoration:none; 
-	transition: background .5s ease; 
-	-moz-transition: background .5s ease; 
-	-webkit-transition: background .5s ease; 
-	-o-transition: background .5s ease; 
+	text-decoration:none;
+	transition: background .5s ease;
+	-moz-transition: background .5s ease;
+	-webkit-transition: background .5s ease;
+	-o-transition: background .5s ease;
 	display:inline-block;
 	cursor:pointer;
 	outline:none;
@@ -424,11 +427,11 @@ a.button_subscribe_green, .button_subscribe_green {
 	background:#30d9a4;
 	color:#fff;
 	padding:12px 20px;
-	text-decoration:none; 
-	transition: background .5s ease; 
-	-moz-transition: background .5s ease; 
-	-webkit-transition: background .5s ease; 
-	-o-transition: background .5s ease; 
+	text-decoration:none;
+	transition: background .5s ease;
+	-moz-transition: background .5s ease;
+	-webkit-transition: background .5s ease;
+	-o-transition: background .5s ease;
 	display:inline-block;
 	cursor:pointer;
 	outline:none;
@@ -445,11 +448,11 @@ a.button_medium_outline, .button_medium_outline {
 	color:#1dd7b2;
 	border:2px solid #1dd7b2;
 	padding:5px 10px;
-	text-decoration:none; 
-	transition: .5s ease; 
-	-moz-transition: .5s ease; 
-	-webkit-transition:.5s ease; 
-	-o-transition: .5s ease; 
+	text-decoration:none;
+	transition: .5s ease;
+	-moz-transition: .5s ease;
+	-webkit-transition:.5s ease;
+	-o-transition: .5s ease;
 	display:inline-block;
 	cursor:pointer;
 	outline:none;
@@ -467,11 +470,11 @@ a.button_big, .button_big{
 	font-size:30px;
 	line-height:32px;
 	padding:20px 50px;
-	text-decoration:none; 
-	transition: background .5s ease; 
-	-moz-transition: background .5s ease; 
-	-webkit-transition: background .5s ease; 
-	-o-transition: background .5s ease; 
+	text-decoration:none;
+	transition: background .5s ease;
+	-moz-transition: background .5s ease;
+	-webkit-transition: background .5s ease;
+	-o-transition: background .5s ease;
 	display:inline-block;
 	cursor:pointer;
 	outline:none;
@@ -487,11 +490,11 @@ a.button_big:hover, .button_big:hover {background:#262c2d;}
 	color:#fff;
 	outline:none;
 	padding:2px 8px;
-	margin-bottom:15px; 
-	text-decoration:none; 
-	transition: background .5s ease; 
-	-moz-transition: background .5s ease; 
-	-webkit-transition: background .5s ease; 
+	margin-bottom:15px;
+	text-decoration:none;
+	transition: background .5s ease;
+	-moz-transition: background .5s ease;
+	-webkit-transition: background .5s ease;
 	-o-transition: background .5s ease;
 	display:inline-block;
 	cursor:pointer;
@@ -507,11 +510,11 @@ a.button_fullwidth, .button_fullwidth {
 	color:#fff;
 	outline:none;
 	padding:7px 12px;
-	text-decoration:none; 
-	transition: background .5s ease; 
-	-moz-transition: background .5s ease; 
-	-webkit-transition: background .5s ease; 
-	-o-transition: background .5s ease; 
+	text-decoration:none;
+	transition: background .5s ease;
+	-moz-transition: background .5s ease;
+	-webkit-transition: background .5s ease;
+	-o-transition: background .5s ease;
 	display:block;
 	width:100%;
 	cursor:pointer;
@@ -530,11 +533,11 @@ a.button_fullwidth-2, .button_fullwidth-2 {
 	outline:none;
 	text-align:center;
 	padding:7px 12px;
-	text-decoration:none; 
-	transition: background .5s ease; 
-	-moz-transition: background .5s ease; 
-	-webkit-transition: background .5s ease; 
-	-o-transition: background .5s ease; 
+	text-decoration:none;
+	transition: background .5s ease;
+	-moz-transition: background .5s ease;
+	-webkit-transition: background .5s ease;
+	-o-transition: background .5s ease;
 	display:block;
 	width:100%;
 	cursor:pointer;
@@ -552,10 +555,10 @@ a.button_fullwidth-3, .button_fullwidth-3 {
 	outline:none;
 	text-align:center;
 	padding:15px 12px;
-	text-decoration:none; 
-	transition: background .5s ease; 
-	-moz-transition: background .5s ease; 
-	-webkit-transition: background .5s ease; 
+	text-decoration:none;
+	transition: background .5s ease;
+	-moz-transition: background .5s ease;
+	-webkit-transition: background .5s ease;
 	-o-transition: background .5s ease;
 	font-size:16px;
 	display:block;
@@ -574,10 +577,10 @@ a.button_fullwidth-3:hover, .button_fullwidth-3:hover  {background:#262c2d; colo
 	color:#1dd7b2;
 	outline:none;
 	padding:13px 24px 13px 24px;
-	text-decoration:none; 
-	transition: background .5s ease; 
-	-moz-transition: background .5s ease; 
-	-webkit-transition: background .5s ease; 
+	text-decoration:none;
+	transition: background .5s ease;
+	-moz-transition: background .5s ease;
+	-webkit-transition: background .5s ease;
 	-o-transition: background .5s ease;
 	display:inline-block;
 	cursor:pointer;
@@ -586,7 +589,7 @@ a.button_fullwidth-3:hover, .button_fullwidth-3:hover  {background:#262c2d; colo
 	text-transform:uppercase;
 	-webkit-font-smoothing: antialiased;
 	outline:none;
-	
+
 }
 .button_outline:hover, a.button_outline:hover {background:#1dd7b2; color:#fff;}
 
@@ -600,10 +603,10 @@ a.button_fullwidth-3:hover, .button_fullwidth-3:hover  {background:#262c2d; colo
 	color:#fff;
 	outline:none;
 	padding:2px 8px 0 8px;
-	text-decoration:none; 
-	transition: background .5s ease; 
-	-moz-transition: background .5s ease; 
-	-webkit-transition: background .5s ease; 
+	text-decoration:none;
+	transition: background .5s ease;
+	-moz-transition: background .5s ease;
+	-webkit-transition: background .5s ease;
 	-o-transition: background .5s ease;
 	cursor:pointer;
 	font-weight:600;
@@ -618,11 +621,11 @@ a.button_fullwidth-3:hover, .button_fullwidth-3:hover  {background:#262c2d; colo
 	border:none;
 	color:#fff;
 	padding:7px 20px;
-	text-decoration:none; 
-	transition: background .5s ease; 
-	-moz-transition: background .5s ease; 
-	-webkit-transition: background .5s ease; 
-	-o-transition: background .5s ease; 
+	text-decoration:none;
+	transition: background .5s ease;
+	-moz-transition: background .5s ease;
+	-webkit-transition: background .5s ease;
+	-o-transition: background .5s ease;
 	display:inline-block;
 	cursor:pointer;
 	font-weight:600;
@@ -630,9 +633,9 @@ a.button_fullwidth-3:hover, .button_fullwidth-3:hover  {background:#262c2d; colo
 	outline:none;
 	background:#282828;
 	position:relative;
-   } 
-   
-.backward {padding:7px 20px 7px 30px;} 
+   }
+
+.backward {padding:7px 20px 7px 30px;}
 
  button[disabled].backward, button[disabled].forward {
 	border:none;
@@ -641,7 +644,7 @@ a.button_fullwidth-3:hover, .button_fullwidth-3:hover  {background:#262c2d; colo
 }
 
 .backward:before {
-	 content: "\f053"; 
+	 content: "\f053";
     font-family: FontAwesome;
     text-decoration: inherit;
     position: absolute;
@@ -650,11 +653,11 @@ a.button_fullwidth-3:hover, .button_fullwidth-3:hover  {background:#262c2d; colo
     left: 20px;
 	text-transform:none;
 	font-size:9px
-   } 
- 
-.forward {padding:7px 30px 7px 20px;}  
+   }
+
+.forward {padding:7px 30px 7px 20px;}
    .forward:before {
-	 content: "\f054"; 
+	 content: "\f054";
     font-family: FontAwesome;
     text-decoration: inherit;
     position: absolute;
@@ -663,8 +666,8 @@ a.button_fullwidth-3:hover, .button_fullwidth-3:hover  {background:#262c2d; colo
     right: 20px;
 	text-transform:none;
 	font-size:9px
-   } 
-   
+   }
+
 .backward:hover, .forward:hover {background:#00aeef; color:#fff;}
 
 /*============================================================================================*/
@@ -714,7 +717,7 @@ a.button_fullwidth-3:hover, .button_fullwidth-3:hover  {background:#262c2d; colo
 }
 .feature i{
 	margin:0;
-	position:absolute; 
+	position:absolute;
 	top:0;
 	left:0;
 	padding:0;
@@ -733,7 +736,7 @@ a.button_fullwidth-3:hover, .button_fullwidth-3:hover  {background:#262c2d; colo
 
 #main-features_green .feature i{
 	margin:0;
-	position:absolute; 
+	position:absolute;
 	top:0;
 	left:0;
 	padding:0;
@@ -903,7 +906,7 @@ a.button_fullwidth-3:hover, .button_fullwidth-3:hover  {background:#262c2d; colo
 	margin-left:5px;
 	margin-right:5px;
 	}
-.adv_search a{ 
+.adv_search a{
  -webkit-border-top-left-radius: 3px;-webkit-border-top-right-radius: 3px; -moz-border-radius-topleft: 3px;-moz-border-radius-topright: 3px;border-top-left-radius: 3px;border-top-right-radius: 3px;
 position:absolute; left:10px; top:-15px; background-color:#f8f8f8; padding:0px 10px; font-size:11px; color:#333; margin:0;}
 .adv_search a:hover{ color:#fff; background:#488dc6;}
@@ -1100,10 +1103,10 @@ ul.social_team li{
 	display: block;
 	height: 40px;
 	}
-.widget_nav_menu {	
+.widget_nav_menu {
 	min-height:100%;
 	height:100%;
-	text-align:center;	
+	text-align:center;
 }
 .project-item-image-container {
 	border: none;
@@ -1136,7 +1139,7 @@ ul.social-bookmarks.team {float:none; margin:0; padding:0; margin:auto; display:
 	margin-bottom:30px;
 }
 .question_box:before {
-    content: "\ec7e"; 
+    content: "\ec7e";
    font-family: 'fontello';
     font-style: normal;
     font-weight: normal;
@@ -1285,11 +1288,11 @@ border-radius: 0;
 	border:2px solid  #8dc63f;
 	color:#8dc63f;
 	padding:15px 35px;
-	text-decoration:none; 
-	transition: background .5s ease; 
-	-moz-transition: background .5s ease; 
-	-webkit-transition: background .5s ease; 
-	-o-transition: background .5s ease; 
+	text-decoration:none;
+	transition: background .5s ease;
+	-moz-transition: background .5s ease;
+	-webkit-transition: background .5s ease;
+	-o-transition: background .5s ease;
 	display:inline-block;
 	cursor:pointer;
 	font-weight:600;
@@ -1299,35 +1302,35 @@ border-radius: 0;
 }
 #complete button:hover{background:#00aeef; color:#fff; border:2px solid  #00aeef;}
 
-/** Floated inputs: ex the gender radio ==================== **/   
+/** Floated inputs: ex the gender radio ==================== **/
 ul.floated {
 	padding:0;
 	margin:0 0 0 0;
-   }   
+   }
 ul.floated li {
 	float:left;
 	margin:0; padding:0;
 	width:27%;
-   } 
+   }
  label.label_gender {padding-left:50px; line-height:42px;}
- 
+
  ul.floated li#age {
 	 width:100px;
 	 margin-right:55px;
-   } 
+   }
 
 ul.data-list{
 	padding:0;
 	margin:0;
 	list-style:none;
 	margin-bottom:30px;
-	} 
+	}
 ul.data-list-2{
 	list-style:none;
 	padding-left:0;
 	margin-left:0;
-	} 
-ul.data-list li {position:relative;  } 
+	}
+ul.data-list li {position:relative;  }
 
 ul.data-list-2 li {
 	   position:relative;
@@ -1336,7 +1339,7 @@ ul.data-list-2 li {
 	   width:100%;
 	   display:block;
    }
-   
+
 ul.data-list-2 li label {
 	float:left;
 	margin-left:60px;
@@ -1344,7 +1347,7 @@ ul.data-list-2 li label {
 	font-weight:400;
 	margin-top:9px;
 	line-height:22px;
-   }  
+   }
 
 ul.data-list#terms  {
 	font-weight:400;
@@ -1353,12 +1356,12 @@ ul.data-list#terms  {
 	font-size:12px;
 	padding:0;
 	text-align:center;
-   }  
+   }
 
 
-/** Errors validation styles and position ==================== **/   
+/** Errors validation styles and position ==================== **/
 
-/** Common style**/   
+/** Common style**/
 label.error{
 	font-size:11px;
 	position: absolute;
@@ -1371,7 +1374,7 @@ label.error{
 	color:#fff;
 	font-weight:normal;
 	padding:0 6px;
-   } 
+   }
   label.error:after {
 	content: '';
 	position: absolute;
@@ -1383,21 +1386,21 @@ label.error{
 	z-index: 1;
 	bottom: -6px;
 	left: 20%;
-   } 
-   
+   }
+
 .styled-select label.error{overflow:visible;}
 
-ul.floated li#age label.error {right:-15px;} 
+ul.floated li#age label.error {right:-15px;}
 
-ul.floated li label.error{right:-50px;} 
+ul.floated li label.error{right:-50px;}
 
 ul.data-list#terms li label.error {
 	left:45%;
 	display:inline-block;
 	width:80px;
-   } 
+   }
 
-/** Error styles for survey questions**/   
+/** Error styles for survey questions**/
 ul.data-list-2 li label.error {
 	   	font-size:11px;
 	   	position: absolute;
@@ -1411,7 +1414,7 @@ ul.data-list-2 li label.error {
 		color:#fff;
 		font-weight:normal;
 		padding:0 6px;
-   }  
+   }
 /* #teachers
 ================================================ */
 ul.teacher_courses{
@@ -1491,14 +1494,14 @@ ul.data-lessons li a.button_red_small{
 	line-height:33px;
 	background: #ededed url(../img/tag_bg.png) no-repeat 91% center;
 	padding:0 28px 0 11px;
-	color:#646464;	
+	color:#646464;
 	-webkit-border-top-right-radius: 20px;
 	-webkit-border-bottom-right-radius: 20px;
 	-moz-border-radius-topright: 20px;
 	-moz-border-radius-bottomright: 20px;
 	border-top-right-radius: 20px;
 	border-bottom-right-radius: 20px;
-	transition: background .5s ease; 
+	transition: background .5s ease;
 }
 .tags a:hover {
 	background-color:#099ad1;
@@ -1562,12 +1565,12 @@ ul.recent_post li:last-child{
 }
 #comments {
 	padding:10px 0 0px 0;
-	margin-bottom:15px;	
+	margin-bottom:15px;
 }
 #comments ul {
 	padding:0;
 	margin:0;
-	list-style:none;	
+	list-style:none;
 }
 #comments ol {
 	padding:0;
@@ -1581,12 +1584,12 @@ ul.recent_post li:last-child{
 .avatar {
 	float:left;
 	margin-right:11px;
-	
+
 }
 .avatar img {
 	-moz-border-radius:3px;
 	-webkit-border-radius:3px;
-	border-radius:3px;	
+	border-radius:3px;
 }
 .comment_right {display:table;	}
 .comment_info {padding-bottom:7px;}
@@ -1686,12 +1689,12 @@ ul#follow_us_contacts  li a:hover i{
    background: #fff url(../img/down_arrow_select.png) no-repeat  right center ;
 	border:1px solid #ededed;
 	margin-bottom:25px;
-   } 
+   }
 .styled-select select::-ms-expand, .styled-select-2 select::-ms-expand {display: none;}
 
-/** VERSION 1.3 CSS Updated ==================== **/	
-.input-icon{position:absolute; right:8px; top:10px; width:32px; height:24px; background-color:#fff; text-align:right; border-left: 1px solid #ececec; color:#ccc; font-size:18px; line-height:24px; text-shadow:none;} 
-/**  End Version 1.3 Updated  **/	
+/** VERSION 1.3 CSS Updated ==================== **/
+.input-icon{position:absolute; right:8px; top:10px; width:32px; height:24px; background-color:#fff; text-align:right; border-left: 1px solid #ececec; color:#ccc; font-size:18px; line-height:24px; text-shadow:none;}
+/**  End Version 1.3 Updated  **/
 
 .input-icon i { color:#ccc; font-size:18px; line-height:24px;}
 .form-group { position:relative; margin-bottom:20px;}
@@ -1743,7 +1746,7 @@ input.form-control:focus, textarea.form-control:focus, select.form-control:focus
 }
 /* Newsletter */
 input.form-control#email_newsletter {
-margin-bottom:0; 
+margin-bottom:0;
 background-color:#262626;
 border:none;
 height:52px;
@@ -1774,7 +1777,7 @@ label.error{
 	color:#fff;
 	font-weight:600;
 	padding:0 6px;
-   } 
+   }
   label.error:after {
 	content: '';
 	position: absolute;
@@ -1786,7 +1789,7 @@ label.error{
 	z-index: 1;
 	bottom: -6px;
 	left: 20%;
-   } 
+   }
   .login-or {
     position: relative;
     font-size: 18px;
@@ -1952,7 +1955,7 @@ ul.plan-features{
 .ribbon {
 	width:99px;
 	height:97px;
-	position:absolute; 
+	position:absolute;
 	left:-7px;
 	top:-7px;
 	display:block;
@@ -1987,15 +1990,15 @@ text-align:center;
 .plan-tall + .plan {
   border-left: 0;
 }
-/** VERSION 1.3 CSS New ==================== **/	
-/* Pricing tables */	
+/** VERSION 1.3 CSS New ==================== **/
+/* Pricing tables */
 #pricing_2 {
 	margin-top:20px;
 }
 .ribbon_2 {
 	width:99px;
 	height:97px;
-	position:absolute; 
+	position:absolute;
 	left:-5px;
 	top:-5px;
 	display:block;
@@ -2058,7 +2061,7 @@ border:1px solid #333;
 .pricing-table p strong{
 		font-weight:600;
 	}
-	
+
 .pricing-table .pricing-table-header {
 	color:#fff;
 
@@ -2109,7 +2112,7 @@ border:1px solid #333;
 	font-size:22px;
 	font-weight:400;
 }
-/**User logged panel on header  **/	
+/**User logged panel on header  **/
 ul.user_panel {
 	list-style: none;
 	margin:10px 0 0 0;
@@ -2120,7 +2123,7 @@ ul.user_panel a.dropdown-toggle{color:#fff;}
 
 .rating_2{color: #FC0;}
 
-/** Member page +  teacher profile  **/	
+/** Member page +  teacher profile  **/
 .box_style_1.profile{ padding-top:30px;}
 .profile ul{
 	text-transform:none;
@@ -2194,7 +2197,7 @@ html #boxed  {
  body#boxed  {
 	 background: #999 url(../img/pattern_1.png) repeat;
 }
-/**  End Version 1.3 New ====================== **/	
+/**  End Version 1.3 New ====================== **/
 
 
 /*============================================================================================*/
@@ -2294,7 +2297,7 @@ img.speaker {
 /* End carousel */
 
 .item blockquote {
-    border-left: none; 
+    border-left: none;
     margin: 0;
 }
 
@@ -2311,21 +2314,21 @@ img.speaker {
 
 
 #toTop {width:100px;border:1px solid #ccc;background:#f7f7f7;text-align:center;padding:5px;position:fixed; bottom:10px;right:10px;cursor:pointer; display:none;color:#333;font-size:11px;}
-.img-circle.styled { 
+.img-circle.styled {
 	background-color:#ededed;
-	-moz-box-shadow: 0px 0px 0px 5px #ededed; 
-	-webkit-box-shadow: 0px 0px 0px 5px #ededed; 
+	-moz-box-shadow: 0px 0px 0px 5px #ededed;
+	-webkit-box-shadow: 0px 0px 0px 5px #ededed;
 	box-shadow: 0px 0px 0px 5px #ededed;
 	margin:auto;
 }
 
-/** Collapse **/   
+/** Collapse **/
 .panel-title a {display:block;}
 
-/** tabs **/   
+/** tabs **/
 .tab-content{padding-top:15px;}
 
-/** List styles **/ 
+/** List styles **/
 ul.latest_news {
 	list-style:none;
 	margin:0 0 0 0;
@@ -2508,7 +2511,7 @@ ul.list_2 li a:hover {
     rgb(10, 165, 148) 85px 85px,
     rgb(10, 165, 148) 86px 86px;
 	}
-	
+
 	.circ-wrapper.red {
 		width: 80px;
 		height: 80px;
@@ -2606,7 +2609,7 @@ ul.list_2 li a:hover {
     rgb(201, 87, 84) 85px 85px,
     rgb(201, 87, 84) 86px 86px;
 	}
-	
+
 	.circ-wrapper.blue {
 		width: 80px;
 		height: 80px;
@@ -2730,7 +2733,7 @@ ul.list_2 li a:hover {
 	ul.floated li#age{
 		margin-right:20px;
    }
-/** VERSION 1.3 CSS New ==================== **/	
+/** VERSION 1.3 CSS New ==================== **/
 #boxed  {width:980px;}
 /**  End Version 1.3 New  **/
 }
@@ -2741,8 +2744,8 @@ ul.list_2 li a:hover {
       padding: 0 40px 30px 40px;
       margin-top: 30px;
     }
-	
-/** VERSION 1.3 CSS New ==================== **/	
+
+/** VERSION 1.3 CSS New ==================== **/
 .plan-tall + .plan {border: solid #dddddd 1px;}
 .plan-tall {margin-right:0;}
 .col-md-4.plan:first-child {
@@ -2753,11 +2756,11 @@ ul.list_2 li a:hover {
 html #boxed  {width:760px;}
 /**  End Version 1.3 New  **/
 }
-	
+
 /* From tablet portrait to mobile */
 @media (max-width: 767px)  {
     #quote-carousel .carousel-indicators {
-        bottom: -20px !important;  
+        bottom: -20px !important;
     }
     #quote-carousel .carousel-indicators li {
         display: inline-block;
@@ -2773,7 +2776,7 @@ html #boxed  {width:760px;}
 input.form-control#email_newsletter {
 width:80%;
 margin:auto;
-margin-bottom:15px; 
+margin-bottom:15px;
 }
 #apply{margin-right:40px;}
 #login_top{margin-right:40px;}
@@ -2781,15 +2784,15 @@ margin-bottom:15px;
 #top-wizard {padding:15px 6s0px;}
 #middle-wizard {padding: 20px 30px 20px 30px;}
 
-ul.floated li#age {margin-bottom:-10px; } 
-   
+ul.floated li#age {margin-bottom:-10px; }
+
 ul.floated li {
 	float:none;
 	margin:0; padding:0;
 	width:50%;
 	padding-bottom:10px;
    }
-.col-md-4.plan:first-child, 
+.col-md-4.plan:first-child,
 .col-md-4.plan:last-child {
 		margin-right: 0px;
 		margin-left: 0px;
@@ -2816,7 +2819,6 @@ ul.floated li {
 #strips-course{
 	padding:30 0 30px 0;
 }
-/* Typography*/
 p.lead.boxed{
 	font-size:22px;
 	line-height:24px;
@@ -2831,11 +2833,11 @@ p.lead.boxed{
 	font-size:50px;
 	margin-top:0;
 }
-/** VERSION 1.3 CSS New ==================== **/	
+/** VERSION 1.3 CSS New ==================== **/
 ul.user_panel {margin:8px 45px 0 0;}
 html #boxed  {width:100%}
-/**  End Version 1.3 New  **/	
-}	
+/**  End Version 1.3 New  **/
+}
 
 /* Mobile portrait */
 @media (max-width: 480px) {
@@ -2885,6 +2887,9 @@ footer h3 {
 	font-size:22px;
 	line-height:24px;
 }
+footer {
+	background-size: 90% auto;
+}
 #top-wizard {padding:15px 30px;}
 #bottom-wizard {padding:15px 30px;}
 .backward, .forward, button[disabled].backward, button[disabled].forward  {
@@ -2892,12 +2897,12 @@ footer h3 {
 	width:50px;
 	padding:0;
 	height:40px;
-   } 
+   }
 .backward:before, .forward:before, button[disabled].backward:before, button[disabled].forward:before {
 	text-indent:0;
 	top:12px;
 	font-size:16px;
-   } 
+   }
 #complete{padding: 0 25px 15px 25px;}
 #complete h3{ font-size:18px; margin-bottom:20px}
 #complete i {font-size:80px;padding:0;}


### PR DESCRIPTION
- Move latest posts and tags to the bottom of page to let blog content
  display on the top in Mobile layout
- Adjust company logo's background-size in footer to make sure it
  doesn't get crop in screen less than 480px (eg. iPhone 5)
- Break `<code>` block to prevent unexpected horizontal scroll bar

原始示意圖如下：

![default](https://cloud.githubusercontent.com/assets/7748552/17900960/fdfc93be-6993-11e6-8420-95495586b7c4.png)
