### PR TITLE
增加支援簡易轉址

### DIFF
--- a/config/application.yml.example
+++ b/config/application.yml.example
@@ -15,6 +15,9 @@ defaults: &defaults
   index_pictures:
     sizes: ['400w', '600w', '1280w', '1920w', '2560w']
     default_size: '1280w'
+  # alias:
+    # - from: reactjs
+    #   to: /talks/react-redux-2017-1
 
 development: &development
   <<: *defaults

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,10 @@ Rails.application.routes.draw do
     get 'courses/:id', to: redirect('/talks/%{id}')
     get 'courses', to: redirect('/talks')
     post 'rental/calculate'
+
+    Settings.alias.each do |path|
+      get path.from, to: redirect(path.to)
+    end
   end
 
   get Settings.admin_path_prefix, to: "admin#dashboard", as: :admin_root


### PR DESCRIPTION
config/application.yml

```
default:
  alias:
    - from: reactjs
      to: /talks/react-redux-2017-1
```

可以將網址由 /reactjs 轉到 /talks/react-redux-2017-1