### PR TITLE
rmagick doesn't support imagemagick 7 yet

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Software Dependencies (OS X)
 ----------------------------
 
 ```bash
-$ brew install postgres redis imagemagick pkg-config
+$ brew install postgres redis imagemagick@6 pkg-config
 ```
 
 Setup


### PR DESCRIPTION
rmagick 尚未支援新版的 imagemagick
直接 `brew install imagemagick` 的話會裝到 7 版的