### PR TITLE
Fix: /camps speaker links not responding to clicks

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Setup
 
 ```
 $ bundle install
+$ npm install
 $ cp config/application.yml.example config/application.yml
 $ cp config/database.yml.example config/database.yml
 $ rake db:setup dev:fake

--- a/app/views/shared/_carousel.html.erb
+++ b/app/views/shared/_carousel.html.erb
@@ -2,7 +2,7 @@
      data-autoplay="<%= latency ||= 3000 %>"
      data-slides-per-view="<%= slidesPerView ||= 'auto' %>"
      data-gallery="<%= gallery ||= false %>" data-loop="<%= loop ||= true %>" data-slides-per-group="<%= slidesPerGroup ||= 1 %>">
-  <div class="swiper-wrapper gallery">
+  <div class="swiper-wrapper">
     <% if action_name == "space"%>
       <% items.to_a.each do |items_in_a_slide| %>
         <figure class="swiper-slide">


### PR DESCRIPTION
Get rid of the incorrect "onThumbnailsClick" click event listener (which calls event.preventDefault) by removing the gallery class.