### PR TITLE
Enhance vertical rhythm for post content

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -19,4 +19,5 @@
 @import "bootstrap-theme";
 @import "bootstrap-element";
 @import "guest";
+@import "application/news-content";
 

--- a/app/assets/stylesheets/application/news-content.scss
+++ b/app/assets/stylesheets/application/news-content.scss
@@ -1,0 +1,50 @@
+.news-content {
+  p {
+    line-height: 24px;
+    margin: 0 0 24px;
+  }
+
+  h1 {
+    line-height: 48px;
+    margin: 30px 0 24px;
+  }
+
+  h2 {
+    line-height: 38px;
+    margin: 30px 0 24px;
+  }
+
+  h3 {
+    line-height: 36px;
+    margin: 0 0 12px;
+  }
+
+  h4 {
+    line-height: 24px;
+    margin: 0 0 12px;
+  }
+
+  blockquote {
+    margin: 0 0 24px;
+  }
+
+  pre {
+    margin: 0 0 24px;
+  }
+
+  ul, ol {
+    margin: 0 0 24px;
+  }
+
+  img {
+    margin: 0 0 24px;
+  }
+
+  hr {
+    margin: 24px 0;
+  }
+
+  .news-title {
+    margin: 0;
+  }
+}

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -11,7 +11,7 @@
         <% if @post.image.present? %>
           <%= image_tag(@post.image.thumb, class: 'bottom-spacing-sm') %>
         <% end %>
-        <h1><small class="text-black"><%= tr @post, :title %></small></h1>
+        <h1 class="news-title"><small class="text-black"><%= tr @post, :title %></small></h1>
         <div class="text-grey">
           <%= "#{t('.by')}#{@post.author.try(:name)}" %>
           <small class="left-spacing-sm"><%= l @post.publish_at, format: :short %></small>

--- a/config/application.yml.example
+++ b/config/application.yml.example
@@ -61,6 +61,8 @@ defaults: &defaults
       app_id: needed_to_fill
       sandbox_app_key: needed_to_fill
       app_key: needed_to_fill
+  facebook:
+    pixel_id: needed_to_fill
 
 development:
   <<: *defaults


### PR DESCRIPTION
做了一些文章內文的調整來增加易讀性。

## Sample - 1

### Before

![before-1](https://user-images.githubusercontent.com/3784687/36018718-c202ddb8-0db7-11e8-851b-888ce5e466db.png)

### After

![after-1](https://user-images.githubusercontent.com/3784687/36018716-c1b461ec-0db7-11e8-855c-7d2ae8aaf005.png)

## Sample - 2

### Before
![before-2](https://user-images.githubusercontent.com/3784687/36018719-c22a0c44-0db7-11e8-82f2-ac5e25766f45.png)

### After

![after-2](https://user-images.githubusercontent.com/3784687/36018717-c1dc756a-0db7-11e8-8331-bb0a3f12f5f7.png)

## Sample - 3

### Before

![before-3](https://user-images.githubusercontent.com/3784687/36018738-ce3d6d64-0db7-11e8-930d-95a5a5eba39a.png)

### After

![after-3](https://user-images.githubusercontent.com/3784687/36018737-ce1520c0-0db7-11e8-89fb-c8dbe50586db.png)
