### PR TITLE
Auto generate sitemap after deploy

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -49,6 +49,7 @@ ask :branch, proc { `git rev-parse --abbrev-ref HEAD`.chomp }.call
 # set :keep_releases, 5
 
 after :'deploy:publishing', :'deploy:restart'
+after 'deploy:publishing', 'sitemap:create'
 namespace :deploy do
 
   desc 'Restart application'


### PR DESCRIPTION
Sitemap Generator 有支援 Capistrano 卻沒有自動加上生成功能，可能會造成剛 Deploy 找不到 sitemap.xml.gz 的情況。